### PR TITLE
Feature/disable collection count

### DIFF
--- a/flask_rest_jsonapi/data_layers/alchemy.py
+++ b/flask_rest_jsonapi/data_layers/alchemy.py
@@ -125,7 +125,7 @@ class SqlalchemyDataLayer(BaseDataLayer):
 
         query = self.retrieve_object_query(view_kwargs, filter_field, filter_value)
 
-        if hasattr(self, "resource"):
+        if self.resource is not None:
             for i_plugins in self.resource.plugins:
                 try:
                     query = i_plugins.data_layer_get_object_update_query(

--- a/flask_rest_jsonapi/data_layers/alchemy.py
+++ b/flask_rest_jsonapi/data_layers/alchemy.py
@@ -146,6 +146,15 @@ class SqlalchemyDataLayer(BaseDataLayer):
 
         return obj
 
+    def get_collection_count(self, query, qs, view_kwargs) -> int:
+        """
+        :param query: SQLAlchemy query
+        :param qs: QueryString
+        :param view_kwargs: view kwargs
+        :return:
+        """
+        return query.count()
+
     def get_collection(self, qs, view_kwargs):
         """Retrieve a collection of objects through sqlalchemy
 
@@ -174,7 +183,7 @@ class SqlalchemyDataLayer(BaseDataLayer):
         if qs.sorting:
             query = self.sort_query(query, qs.sorting)
 
-        object_count = query.count()
+        objects_count = self.get_collection_count(query, qs, view_kwargs)
 
         if getattr(self, "eagerload_includes", True):
             query = self.eagerload_includes(query, qs)
@@ -185,7 +194,7 @@ class SqlalchemyDataLayer(BaseDataLayer):
 
         collection = self.after_get_collection(collection, qs, view_kwargs)
 
-        return object_count, collection
+        return objects_count, collection
 
     def update_object(self, obj, data, view_kwargs):
         """Update an object through sqlalchemy

--- a/flask_rest_jsonapi/data_layers/base.py
+++ b/flask_rest_jsonapi/data_layers/base.py
@@ -5,6 +5,10 @@ you must inherit from this base class
 """
 
 import types
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from flask_rest_jsonapi.resource import Resource
 
 
 class BaseDataLayer:
@@ -38,6 +42,11 @@ class BaseDataLayer:
 
         :param dict kwargs: information about data layer instance
         """
+
+        # initing this attribute here in the first place
+        # because it can be easily overridden by kwargs below
+        self.resource: Optional['Resource'] = None
+
         if kwargs.get("methods") is not None:
             self.bound_rewritable_methods(kwargs["methods"])
             kwargs.pop("methods")
@@ -46,6 +55,17 @@ class BaseDataLayer:
 
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+    def post_init(self):
+        """
+        Post init stage.
+
+        At this moment self.resource is already defined
+        and the layer can do any post init stuff here
+
+        NOTE that the data layer is inited for each request
+        :return:
+        """
 
     def create_object(self, data, view_kwargs):
         """Create an object

--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -55,6 +55,7 @@ class Resource(MethodView):
         """Constructor of a resource instance"""
         if hasattr(cls, "_data_layer"):
             cls._data_layer.resource = cls
+            cls._data_layer.post_init()
 
         return super().__new__(cls)
 


### PR DESCRIPTION
Closes #3 

- Create a separate method get_collection_count in the alchemy layer https://github.com/AdCombo/flask-rest-jsonapi/pull/4/commits/39c1498f24346ed391f1316f252e9f49fef85541
- Create post_init method for base data layer, use it in the resource https://github.com/AdCombo/flask-rest-jsonapi/pull/4/commits/e51c676c603d09577c8a39b85e34a9ce6aa38cd9. This method is called after the resource is assigned to the layer. Also make the `resource` attribute on the data layer mandatory, though optional
- Override `post_init` and set `disable_collection_count` and `default_collection_count` in alchemy layer https://github.com/AdCombo/flask-rest-jsonapi/pull/4/commits/46df5de0d13c814aff84f02405dacc88837239cc
- tests coverage https://github.com/AdCombo/flask-rest-jsonapi/pull/4/commits/0e7731074be488093b8798512873658ad45e3d0a
