### PR TITLE
Feature to support 'in' clause based on jsonapi filter=1,2,3 - BUG: #189 #190

### DIFF
--- a/flask_combo_jsonapi/querystring.py
+++ b/flask_combo_jsonapi/querystring.py
@@ -60,8 +60,18 @@ class QueryStringManager(object):
         return results
 
     def _simple_filters(self, dict_):
-        return [{"name": key, "op": "eq", "val": value}
-                for (key, value) in dict_.items()]
+        """Return filter list
+                for (key, value) in dict_.items()]	
+        :return list: list of dict for filter parameters. Includes support for 'in' for list values
+        """
+        filter_list = []
+        for (key, value) in dict_.items():
+            operator = 'eq'
+            if isinstance(value, list):
+                operator = 'in'
+            filter_list.append({"name": key, "op": operator, "val": value})
+        return filter_list
+
 
     @property
     def querystring(self):


### PR DESCRIPTION
This is a simple and quick idea to support "IN" clause based on jsonapi specification:

filter[id]=1,2,3

Hope this helps