### PR TITLE
Fix resource detail not found

### DIFF
--- a/flask_combo_jsonapi/resource.py
+++ b/flask_combo_jsonapi/resource.py
@@ -188,7 +188,10 @@ class ResourceList(Resource, metaclass=ResourceMeta):
 
         obj = self.create_object(data, kwargs)
 
-        result = schema.dump(obj)
+        if obj is None:
+            result = {"data": None}
+        else:
+            result = schema.dump(obj)
 
         if result["data"].get("links", {}).get("self"):
             final_result = (result, 201, {"Location": result["data"]["links"]["self"]})


### PR DESCRIPTION
there's a feature inside marshmallow
when dumping, if object doesn't have value, marshmallow provides default value, even if the object is `None`

`Fields.serialize`:
```
            if value is missing_ and hasattr(self, "default"):
                default = self.default
```
If `default` is removed from schema's fields, response is as expected (`{"data": null}`)

we can skip dumping object using schema if returned object is None, because we want to return null on object not found