### PR TITLE
Remove apispec from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ simplejson
 Flask>=1.0.1
 marshmallow==3.2.1
 marshmallow_jsonapi==0.22.0
-apispec>=2.0.2
 sqlalchemy


### PR DESCRIPTION
apispec is required for ApiSpec plugin (combojsonapi) and is not used in flask-combo-jsonapi directly 