### PR TITLE
Ensure that status message is included on status line

### DIFF
--- a/flask_combo_jsonapi/decorators.py
+++ b/flask_combo_jsonapi/decorators.py
@@ -73,9 +73,11 @@ def jsonapi_exception_formatter(func):
         try:
             return func(*args, **kwargs)
         except JsonApiException as e:
+            # If status is just a numeric code, convert it to an int so that
+            # flask expands it to a valid HTTP status line in the response.
             try:
                 status = int(e.status)
-            except:
+            except ValueError:
                 status = e.status
             return make_response(jsonify(jsonapi_errors([e.to_dict()])),
                                  status,

--- a/flask_combo_jsonapi/decorators.py
+++ b/flask_combo_jsonapi/decorators.py
@@ -73,8 +73,12 @@ def jsonapi_exception_formatter(func):
         try:
             return func(*args, **kwargs)
         except JsonApiException as e:
+            try:
+                status = int(e.status)
+            except:
+                status = e.status
             return make_response(jsonify(jsonapi_errors([e.to_dict()])),
-                                 e.status,
+                                 status,
                                  headers)
         except Exception as e:
             api_ex = format_http_exception(e)


### PR DESCRIPTION
This fixes a bug where all API errors would result in an internal server error under Apache's mod_wsgi.

The code currently returns a status line consisting of just the numeric code, i.e. `400` rather than `400 BAD REQUEST`.  This results in an error of `ValueError: no space following status code` from mod_wsgi.

This PR fixes this by casting the status to an integer if it is just an integer, which prompts Flask to fill in the rest of the status line.

